### PR TITLE
EGP-16: Update proposal description urls, fix bug displaying GSC proposals

### DIFF
--- a/apps/council-ui/pages/proposals/details.tsx
+++ b/apps/council-ui/pages/proposals/details.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { ReactElement, useMemo, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { councilConfigs } from "src/config/council.config";
+import { ProposalConfig } from "src/config/CouncilConfig";
 import { EnsRecords, getBulkEnsRecords } from "src/ens/getBulkEnsRecords";
 import {
   getProposalStatus,
@@ -241,10 +242,21 @@ function useProposalDetailsPageData(
   const { context, coreVoting, gscVoting } = useCouncil();
   const provider = context.provider;
   const chainId = useChainId();
-  const proposalConfigs = councilConfigs[chainId].coreVoting.proposals;
-  const votingContractName = councilConfigs[chainId].coreVoting.name;
+
+  // Default to the coreVoting, but if it's gsc grab the gsc name and proposal
+  // configs instead
+  let proposalConfigs = councilConfigs[chainId].coreVoting.proposals;
+  let votingContractName = councilConfigs[chainId].coreVoting.name;
+  if (gscVoting && votingContractAddress === gscVoting.address) {
+    proposalConfigs = councilConfigs[chainId].gscVoting?.proposals as Record<
+      string,
+      ProposalConfig
+    >;
+    votingContractName = councilConfigs[chainId].gscVoting?.name as string;
+  }
 
   const queryEnabled = votingContractAddress !== undefined && id !== undefined;
+
   return useQuery<ProposalDetailsPageData>({
     queryKey: ["proposalDetailsPage", id],
     enabled: queryEnabled,

--- a/apps/council-ui/src/config/mainnet.ts
+++ b/apps/council-ui/src/config/mainnet.ts
@@ -144,14 +144,14 @@ export const mainnetCouncilConfig: CouncilConfig = {
       },
       10: {
         descriptionURL:
-          "https://snapshot.org/#/elfi.eth/proposal/0xbfd1f2b0977aed2aa1cfaf38f5a79fc3b7b21a49ff8b556ed3d11e83f14ad382",
+          "https://docs.google.com/document/d/1tutU6ZzIvOCv3CcdCzUJ_PbPMIUM-xu3gAhQ0qkV1Z0/edit",
         targets: [],
         calldatas: [],
         title: "EGP16-2: Begin unwinding of the main treasury",
         sentenceSummary:
           "This PR is the follow-up from the approved Snapshot proposal, targeting the unwinding of the main treasury.",
         paragraphSummary:
-          "The main treasury, accessible here, holds approx. 192,000 USDC in assets wound up in Yearn positions. These assets come from affiliate fees via Yearn. A separate proposal manages the unwinding of the GSC treasury, which contains about 60,000 USDC. Following this proposal, two more will be necessary to unwind CRV positions and to consolidate assets into USDC, DAI, and ETH.",
+          "The main treasury  holds approx. 192,000 USDC in assets wound up in Yearn positions. These assets come from affiliate fees via Yearn. A separate proposal manages the unwinding of the GSC treasury, which contains about 60,000 USDC. Following this proposal, two more will be necessary to unwind CRV positions and to consolidate assets into USDC, DAI, and ETH.",
       },
     },
   },
@@ -176,14 +176,14 @@ export const mainnetCouncilConfig: CouncilConfig = {
     proposals: {
       0: {
         descriptionURL:
-          "https://snapshot.org/#/elfi.eth/proposal/0xbfd1f2b0977aed2aa1cfaf38f5a79fc3b7b21a49ff8b556ed3d11e83f14ad382",
+          "https://docs.google.com/document/d/17tR4ZjibQyfAma3QfklA0FTA4n6S3lGEXXWMzT75K-k/edit",
         targets: [],
         calldatas: [],
         title: "EGP16-1: Unwind GSC Treasury",
         sentenceSummary:
           "This PR follows on from the approved snapshot proposal to unwind the GSC and main treasury, currently living in a gnosis safe, transferring the unwound assets to the main treasury.",
         paragraphSummary:
-          "The GSC treasury, https://app.safe.global/home?safe=eth:0x654be0b5556f8eadbc2d140505445fa32715ef2b or https://zapper.fi/account/0x654be0b5556f8eadbc2d140505445fa32715ef2b, is a gnosis safe currently containing 24 different assets in balancer pools. These assets came from protocol fees traded on the Element protocol. In order to unwind the assets, the LP positions are withdrawn from the Balancer pools. After withdrawal, principal tokens are redeemed through the Element protocol. Once redeemed, the base assets are transferred and consolidated to the main treasury, https://zapper.fi/account/0x82ef450fb7f06e3294f2f19ed1713b255af0f541.",
+          "The GSC treasury  is a gnosis safe currently containing 24 different assets in balancer pools. These assets came from protocol fees traded on the Element protocol. In order to unwind the assets, the LP positions are withdrawn from the Balancer pools. After withdrawal, principal tokens are redeemed through the Element protocol. Once redeemed, the base assets are transferred and consolidated to the main treasury.",
       },
     },
   },


### PR DESCRIPTION
Followup to #6 

Fixes the display issues in GSC proposal details page, and updates the descriptionURL to point to the google doc containing the latest proposal description (snapshot's were out of date, but can't be changed)

<img width="1418" alt="image" src="https://github.com/element-foundation/council-kit/assets/4524175/7619ba5b-1463-4ff0-92d5-103283c44195">
