### PR TITLE
Add EGP-29 Proposal Info

### DIFF
--- a/apps/council-ui/src/config/mainnet.ts
+++ b/apps/council-ui/src/config/mainnet.ts
@@ -197,6 +197,13 @@ export const mainnetCouncilConfig: CouncilConfig = {
         paragraphSummary:
           "The main treasury  holds approx. 192,000 USDC in assets wound up in Yearn positions. These assets come from affiliate fees via Yearn. A separate proposal manages the unwinding of the GSC treasury, which contains about 60,000 USDC. Following this proposal, two more will be necessary to unwind CRV positions and to consolidate assets into USDC, DAI, and ETH.",
       },
+      16: {
+        targets: [],
+        calldatas: [],
+        title: "EGP-29: Hyperdrive Public Testnet Implementation for Element DAO",
+        sentenceSummary: "DELV is creating this governance proposal to deploy a Hyperdrive Public Testnet Implementation for Element DAO on the Sepolia Ethereum Testnet.",
+        paragraphSummary: "This proposal includes the details for deploying the Public Testnet Implementation to Sepolia Ethereum Testnet and running a Hyperdrive UI for users to learn and get educated about how Hyperdrive works, get familiar with the UX of Hyperdrive, and provide feedback on all aspects of the experience.",
+      },
     },
   },
   gscVoting: {


### PR DESCRIPTION
Adds the summary information to the proposal list.  This should land after the proposal actually gets created on-chain.  Here is the snapshot vote:

https://snapshot.org/#/elfi.eth/proposal/0x4509680109a3f209dccb8a6e01928b9ab7cbbddd06e0ac41a707eb1529491af0